### PR TITLE
Fixed Unit deletion memory leak

### DIFF
--- a/src/test/testsuite.cpp
+++ b/src/test/testsuite.cpp
@@ -14,6 +14,11 @@ namespace cppanim::test {
 	TestController::TestController() : units(), resultLock(), results()
 	{}
 
+       	TestController::~TestController()
+	{
+		for(auto u : units) delete u;
+	}
+
 	void TestController::addUnit(Unit *u) { units.push_back(u); }
 	void TestController::emplaceUnit(const std::string& uid,
 					 Unit::result_t (*run)())

--- a/src/test/testsuite.hpp
+++ b/src/test/testsuite.hpp
@@ -32,7 +32,8 @@ namespace cppanim::test {
 	public:
 
 		TestController();
-
+		~TestController();
+		
 		static TestController& getInstance();
 
 		void addUnit(Unit *u);


### PR DESCRIPTION
`TestController` has a list of `Unit*`s, and -- for convenience -- `main()` gives ownership to `TestController`. So far, the `Unit`s were never deleted.
This should be replace with move semantics.